### PR TITLE
Fix scrape() not removing previous items

### DIFF
--- a/src/services/scraper.js
+++ b/src/services/scraper.js
@@ -136,12 +136,18 @@ async function scrape() {
       return;
     }
 
-    const config = { easynewsUsername, easynewsPassword, stashdbApiKey };
+      const config = { easynewsUsername, easynewsPassword, stashdbApiKey };
 
-    // Fetch trending scenes from StashDB
-    const targetCount = parseInt(process.env.SCRAPE_COUNT || '100', 10);
-    const scenes = await stashdb.getTrendingScenes(config.stashdbApiKey, targetCount);
-    console.log(`Found ${scenes.length} trending scenes from StashDB`);
+      // Fetch trending scenes from StashDB
+      const targetCount = parseInt(process.env.SCRAPE_COUNT || '100', 10);
+      const scenes = await stashdb.getTrendingScenes(config.stashdbApiKey, targetCount);
+      console.log(`Found ${scenes.length} trending scenes from StashDB`);
+
+      const previousCacheSize = cache.size();
+      if (previousCacheSize > 0) {
+        console.log(`Clearing cache with ${previousCacheSize} scenes from previous scrape`);
+      }
+      cache.clear();
 
     if (scenes.length === 0) {
       console.log('No scenes to process');


### PR DESCRIPTION
Clear the in-memory cache at the start of each `scrape()` run to remove stale scenes from prior scrapes and add a log message for cache clearing.

This fixes issue #1 where the `scrape()` function was not clearing previous items from the cache, leading to an accumulation of old data.

---
<a href="https://cursor.com/background-agent?bcId=bc-cce66d5e-1712-40a3-9068-0a83e3fbbee8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cce66d5e-1712-40a3-9068-0a83e3fbbee8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

